### PR TITLE
Update dockerfile and prefix in version file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,10 @@ FROM centos:7.6.1810
 
 # Install essentials
 RUN yum install -y epel-release
-RUN yum install -y openssh-clients-7.4p1-16.el7
-RUN yum install -y git-1.8.3.1-20.el7
-
-# Install bsdtar and wget
-# TODO: Offload this to a builder when we refine these images. For now we'll just install it
-RUN yum install -y bsdtar-3.1.2-10.el7_2
-RUN yum install -y wget-1.14-18.el7_6.1
+RUN yum install -y openssh-clients
+RUN yum install -y git
+RUN yum install -y bsdtar
+RUN yum install -y wget
 
 # Clean up after ourselves
 RUN yum clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 FROM centos:7.6.1810
 
 # Install essentials
-RUN yum install -y epel-release
-RUN yum install -y openssh-clients
-RUN yum install -y git
-RUN yum install -y bsdtar
-RUN yum install -y wget
-
-# Clean up after ourselves
-RUN yum clean all
+RUN yum install -y epel-release \
+                   openssh-clients \
+                   git \
+                   bsdtar \
+                   wget && \
+                   yum clean all
 
 # Install Ansible and required pip libraries
 COPY resources/get-pip.py /get-pip.py

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ ansible_version         | Ansible version installed on the container            
 The images are built and tagged with Concourse and have the following prefix:
 
 ```
-packer/1.4.2/ansible/2.8.1/container/<CONTAINER_VERSION>
+packer-1.4.2-ansible-2.8.1-container-<CONTAINER_VERSION>
 ```
-The `CONTAINER_VERSION` follows the semantic versioning approach. 
+The `CONTAINER_VERSION` follows the semantic versioning approach.

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-packer/1.4.2/ansible/2.8.1/container/1.0.0
+packer-1.4.2-ansible-2.8.1-container-1.0


### PR DESCRIPTION
Dockerfile was taken from the `infrastructure-packer-runner` which fixed a number of the versions installed via yum. 
These now fail which has resulted in the fixed versions being removed.
Update to the prefix in the version file to match that in the pipeline.