### PR TITLE
AmazonLinux 2 and Install pywinrm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,25 @@
-FROM centos:8
+FROM amazonlinux:2
 
-ARG ANSIBLE_VERSION=2.10.4
 ARG PACKER_VERSION=1.6.6
 
-RUN yum install -y epel-release \
-                openssh-clients \
-                git \
-                wget \
-                bsdtar \
-                python3-pip && \
-                alternatives --set python /usr/bin/python3
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN pip3 install ansible==${ANSIBLE_VERSION} \
-                 boto \
-                 boto3 \
-                 dnspython \
-                 netaddr
+RUN amazon-linux-extras enable python3.8 && \
+    yum clean metadata && \
+    yum install -y \
+    openssh-clients \
+    git \
+    wget \
+    bsdtar \
+    python38 && \
+    yum clean all
+
+# Remove conflicting cracklib-packer symlink
+RUN unlink /usr/sbin/packer
+
+COPY resources/requirements.txt /requirements.txt
+RUN python3.8 -m pip install --no-cache-dir -r /requirements.txt && \
+    rm /requirements.txt
 
 RUN rpm --import http://yum-repository.platform.aws.chdev.org/RPM-GPG-KEY-platform-noarch && \
     yum install -y yum-utils && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN amazon-linux-extras enable python3.8 && \
     yum clean metadata && \
+    yum update -y && \
     yum install -y \
     openssh-clients \
     git \

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,0 +1,7 @@
+ansible==2.10.4
+boto==2.49.0
+boto3==1.24.86
+botocore==1.27.86
+dnspython==2.1.0
+netaddr==0.8.0
+pywinrm==0.4.3


### PR DESCRIPTION
Migrated to AmazonLinux 2 base image
Moved python packages to `requirements.txt` and pinned versions
Added `pywinrm` to python packages
Updated python module install command
Unlinked `cracklib-packer` symlink that conflicts with `packer`

Resolves: DVOP-2320